### PR TITLE
use index -2 to get package name info

### DIFF
--- a/testkitlite/engines/default/runner.py
+++ b/testkitlite/engines/default/runner.py
@@ -119,7 +119,7 @@ class TRunner:
                 if platform.system() == "Linux":
                     filename = filename.split('/')[-2]
                 else:
-                    filename = filename.split('\\')[-1]
+                    filename = filename.split('\\')[-2]
                 if self.filter_rules["execution_type"] == ["manual"]:
                     resultfile = "%s.manual.xml" % filename
                 else:


### PR DESCRIPTION
this is use on Windows,
index -1 is the tests.xml, and -2 is refered to the pacakge name of the tests.xml,
so if use -1 instead of -2, when there are more than one tests.xml in the -f option, testkit-lite will assign them with the same name, and it's make it just testing only one xml
