### PR TITLE
Add checking before operate a XML attribute which could be None.

### DIFF
--- a/testkitlite/engines/default/runner.py
+++ b/testkitlite/engines/default/runner.py
@@ -864,7 +864,10 @@ class TRunner:
         if notes_elm is None:
            notes_elm=etree.Element('notes')
            desc.append(notes_elm)
-        notes_elm.text += "\n"+self._extract_notes(buf,pattern)
+        if notes_elm.text is None:
+           notes_elm.text = self._extract_notes(buf,pattern)
+        else:
+           notes_elm.text += "\n"+self._extract_notes(buf,pattern)
 
     def _extract_notes(self,buf,pattern):
         # util func to split lines in buffer, search for pattern on each line


### PR DESCRIPTION
For fixing the bug TTS-812 (NoneType exception is raised when try to operate a null XML attribute "notes.text"), Add checking before operate this attribute.
