### PR TITLE
remove undesired parameter

### DIFF
--- a/testkit-lite
+++ b/testkit-lite
@@ -477,7 +477,7 @@ Note: \n\
                 killall(http_server_pid)
         print "[ all tasks for testkit lite are accomplished, goodbye ]"
     except Exception, e:
-        print "[ Error: run_and_merge_resultfile from testkit-lite failed, error: %s ]\n" % (testxml, e)
+        print "[ Error: run_and_merge_resultfile from testkit-lite failed, error: %s ]\n" % e
 
 except KeyboardInterrupt, e:
     print "\n[ exiting testkit-lite on user cancel ]\n"


### PR DESCRIPTION
this print should only has one incoming parameter, now it has two.
and it will cause error, so remove one
