### PR TITLE
use restart_client() to replace restart code in checkResult

### DIFF
--- a/testkitlite/engines/default/testkithttpd.py
+++ b/testkitlite/engines/default/testkithttpd.py
@@ -178,18 +178,9 @@ def checkResult(case):
             print "[ Warning: time is out, test case \"%s\" is timeout, set the result to \"BLOCK\", and restart the client ]" % str2str(case.purpose)
             print "[ Error: found unprintable character in case purpose, error: %s ]\n" % e
         case.set_result("BLOCK", "Time is out")
-        TestkitWebAPIServer.start_auto_test = 0
-        print "[ kill existing client, pid: %s ]" % TestkitWebAPIServer.client_process.pid
-        try:
-            TestkitWebAPIServer.client_process.terminate()
-        except:
-            killall(TestkitWebAPIServer.client_process.pid)
-        killAllWidget()
-        print "[ start new client in 2sec ]"
-        time.sleep(2)
-        TestkitWebAPIServer.start_auto_test = 1
+        # restart client
         client_command = TestkitWebAPIServer.default_params["client_command"]
-        start_client(client_command)
+        restart_client(client_command)
     else:
         try:
             print "[ test case \"%s\" is executed in time, and the result is %s ]" % (case.purpose, case.result)


### PR DESCRIPTION
the restart process code from checkResult() is the same as the function restart_client(),
so use it to replace it
