### PR TITLE
Format test_definition.xsd by `xmllint --format`

### DIFF
--- a/xsd/test_definition.xsd
+++ b/xsd/test_definition.xsd
@@ -1,385 +1,263 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-	<xs:element name="suite">
-
-
-		<xs:complexType>
-
-			<xs:sequence minOccurs="1" maxOccurs="unbounded">
-				<xs:element ref="set" minOccurs="0" maxOccurs="unbounded"></xs:element>
-			</xs:sequence>
-
-			<xs:attributeGroup ref="set_attribute_group"></xs:attributeGroup>
-			<xs:attribute name="launcher" type="xs:string"></xs:attribute>
-		</xs:complexType>
-		<xs:unique name="uniqueSetName">
-			<xs:selector xpath=".//set" />
-			<xs:field xpath="@name" />
-		</xs:unique>
-	</xs:element>
-
-	<xs:element name="set">
-
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="capabilities" type="CapabilitiesType"
-					minOccurs="0" maxOccurs="1">
-				</xs:element>
-				<xs:sequence minOccurs="1" maxOccurs="unbounded">
-					<xs:element ref="testcase" minOccurs="0"
-						maxOccurs="unbounded">
-					</xs:element>
-				</xs:sequence>
-			</xs:sequence>
-
-
-
-			<xs:attributeGroup ref="set_attribute_group"></xs:attributeGroup>
-			<xs:attribute name="launcher" type="xs:string"></xs:attribute>
-			<xs:attribute name="set_debug_msg" type="xs:string"></xs:attribute>
-		</xs:complexType>
-		<xs:unique name="uniqueCaseName">
-			<xs:selector xpath=".//testcase" />
-			<xs:field xpath="@id" />
-		</xs:unique>
-	</xs:element>
-
-	<xs:element name="testcase">
-		<xs:complexType>
-			<xs:sequence minOccurs="1">
-				<xs:element ref="description"></xs:element>
-				<xs:element name="categories" type="categories"
-					minOccurs="0" maxOccurs="1">
-				</xs:element>
-				<xs:element name="measurement" type="measurementType"
-					minOccurs="0" maxOccurs="unbounded">
-				</xs:element>
-				<xs:element name="series" type="seriesType" minOccurs="0"
-					maxOccurs="unbounded">
-				</xs:element>
-				<xs:element name="specs" type="specsType" minOccurs="0"
-					maxOccurs="1">
-				</xs:element>
-				<xs:element name="result_info" type="result_info_type"
-					minOccurs="0">
-				</xs:element>
-			</xs:sequence>
-
-			<xs:attributeGroup ref="case_attribute_group"></xs:attributeGroup>
-		</xs:complexType>
-	</xs:element>
-
-	<xs:element name="steps">
-		<xs:complexType>
-			<xs:sequence minOccurs="0" maxOccurs="unbounded">
-				<xs:element ref="step"></xs:element>
-			</xs:sequence>
-		</xs:complexType>
-		<xs:unique name="uniqueStepName">
-			<xs:selector xpath=".//step" />
-			<xs:field xpath="@order" />
-		</xs:unique>
-	</xs:element>
-
-	<xs:attributeGroup name="set_attribute_group">
-
-		<xs:attribute name="name" type="xs:anyURI" use="required"></xs:attribute>
-		<xs:attribute name="type" type="xs:string"></xs:attribute>
-	</xs:attributeGroup>
-
-	<xs:attributeGroup name="case_attribute_group">
-
-		<xs:attribute name="id" use="required">
-			<xs:simpleType>
-				<xs:restriction base="xs:string">
-					<xs:minLength value="1"></xs:minLength>
-					<xs:whiteSpace value="collapse"></xs:whiteSpace>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-
-		<xs:attribute name="priority" type="priority_simple_type"
-			use="required">
-		</xs:attribute>
-
-		<xs:attribute name="execution_type" type="execution_type_simple_type"
-			use="required">
-		</xs:attribute>
-
-		<xs:attribute name="component" type="xs:string"></xs:attribute>
-
-		<xs:attribute name="requirement_ref" type="xs:anyURI"
-			use="optional">
-		</xs:attribute>
-
-		<xs:attribute name="status" type="status_type" use="required"></xs:attribute>
-
-		<xs:attribute name="type" type="case_type_type" use="required">
-		</xs:attribute>
-		<xs:attribute name="purpose" type="xs:string"></xs:attribute>
-		<xs:attribute name="result" type="xs:string"></xs:attribute>
-		<xs:attribute name="onload_delay" type="xs:int" use="optional"
-			default="3">
-		</xs:attribute>
-	</xs:attributeGroup>
-
-	<xs:simpleType name="priority_simple_type">
-		<xs:restriction base="xs:string">
-
-			<xs:enumeration value="P0"></xs:enumeration>
-
-			<xs:enumeration value="P1"></xs:enumeration>
-
-			<xs:enumeration value="P2"></xs:enumeration>
-
-			<xs:enumeration value="P3"></xs:enumeration>
-
-			<xs:enumeration value="P4"></xs:enumeration>
-
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="execution_type_simple_type">
-		<xs:restriction base="xs:string">
-
-			<xs:enumeration value="auto"></xs:enumeration>
-
-			<xs:enumeration value="manual"></xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="status_type">
-		<xs:restriction base="xs:string">
-
-			<xs:enumeration value="designed"></xs:enumeration>
-
-			<xs:enumeration value="ready"></xs:enumeration>
-
-			<xs:enumeration value="approved"></xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-
-	<xs:simpleType name="case_type_type">
-		<xs:restriction base="xs:string">
-
-			<xs:enumeration value="functional_positive"></xs:enumeration>
-
-			<xs:enumeration value="functional_negative"></xs:enumeration>
-
-			<xs:enumeration value="security"></xs:enumeration>
-
-			<xs:enumeration value="performance"></xs:enumeration>
-
-			<xs:enumeration value="reliability"></xs:enumeration>
-
-			<xs:enumeration value="portability"></xs:enumeration>
-
-			<xs:enumeration value="maintainability"></xs:enumeration>
-
-			<xs:enumeration value="compliance"></xs:enumeration>
-
-			<xs:enumeration value="user_experience"></xs:enumeration>
-
-			<xs:enumeration value="undefined"></xs:enumeration>
-		</xs:restriction>
-	</xs:simpleType>
-
-
-	<xs:element name="purpose" type="xs:anySimpleType"></xs:element>
-
-	<xs:element name="notes" type="xs:string"></xs:element>
-
-	<xs:element name="pre_condition" type="xs:string"></xs:element>
-
-	<xs:element name="post_condition" type="xs:string"></xs:element>
-
-	<xs:element name="description">
-
-		<xs:complexType>
-
-			<xs:sequence minOccurs="1" maxOccurs="unbounded">
-
-				<xs:choice minOccurs="0" maxOccurs="1">
-					<xs:element ref="notes"></xs:element>
-				</xs:choice>
-
-				<xs:choice minOccurs="0" maxOccurs="1">
-					<xs:element ref="pre_condition"></xs:element>
-				</xs:choice>
-
-				<xs:choice minOccurs="0" maxOccurs="1">
-					<xs:element ref="post_condition"></xs:element>
-				</xs:choice>
-
-				<xs:element ref="steps" minOccurs="1" maxOccurs="1"></xs:element>
-
-				<xs:choice minOccurs="0" maxOccurs="1">
-					<xs:element ref="test_script_entry"></xs:element>
-				</xs:choice>
-
-
-			</xs:sequence>
-
-		</xs:complexType>
-	</xs:element>
-
-	<xs:element name="step">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="step_desc" type="xs:string"></xs:element>
-				<xs:element name="expected" type="xs:string"></xs:element>
-			</xs:sequence>
-			<xs:attribute name="order" type="xs:int"></xs:attribute>
-		</xs:complexType>
-	</xs:element>
-
-	<xs:element name="test_script_entry">
-		<xs:complexType>
-			<xs:simpleContent>
-				<xs:extension base="xs:string">
-					<xs:attribute name="test_script_expected_result" type="xs:string"
-						default="0">
-					</xs:attribute>
-					<xs:attribute name="timeout" type="xs:int" default="90">
-					</xs:attribute>
-					<xs:attribute name="location" type="xs:string" default="device">
-					</xs:attribute>
-				</xs:extension>
-			</xs:simpleContent>
-		</xs:complexType>
-	</xs:element>
-
-	<xs:complexType name="result_info_type">
-		<xs:sequence minOccurs="0">
-			<xs:element name="actual_result" type="xs:string"></xs:element>
-			<xs:element name="start" type="xs:string"></xs:element>
-			<xs:element name="end" type="xs:string"></xs:element>
-			<xs:element name="stdout" type="xs:string" minOccurs="0"></xs:element>
-			<xs:element name="stderr" type="xs:string" minOccurs="0"></xs:element>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="measurementType">
-		<xs:attribute name="name" type="xs:string"></xs:attribute>
-		<xs:attribute name="value" type="xs:string"></xs:attribute>
-		<xs:attribute name="unit" type="xs:string"></xs:attribute>
-		<xs:attribute name="target" type="xs:string"></xs:attribute>
-		<xs:attribute name="failure" type="xs:string"></xs:attribute>
-		<xs:attribute name="power" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-	<xs:complexType name="seriesType">
-		<xs:sequence>
-			<xs:element name="measurement" type="simpleMeasurementType"
-				minOccurs="1" maxOccurs="unbounded"></xs:element>
-		</xs:sequence>
-		<xs:attribute name="name" type="xs:string"></xs:attribute>
-		<xs:attribute name="group" type="xs:string"></xs:attribute>
-		<xs:attribute name="unit" type="xs:string"></xs:attribute>
-		<xs:attribute name="interval" type="xs:string"></xs:attribute>
-		<xs:attribute name="interval_unit" type="xs:string"></xs:attribute>
-		<xs:attribute name="power" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-	<xs:complexType name="simpleMeasurementType">
-		<xs:attribute name="value" type="xs:string"></xs:attribute>
-		<xs:attribute name="file" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-
-	<xs:complexType name="categories">
-		<xs:sequence>
-			<xs:element name="category" type="xs:string" maxOccurs="unbounded"
-				minOccurs="0"></xs:element>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:element name="test_definition">
-		<xs:complexType>
-			<xs:sequence minOccurs="1" maxOccurs="unbounded">
-				<xs:element name="environment" type="BuildInfoType"
-					minOccurs="0">
-				</xs:element>
-				<xs:element name="summary" type="summaryType" minOccurs="0">
-				</xs:element>
-				<xs:element ref="suite" minOccurs="1" maxOccurs="unbounded">
-				</xs:element>
-			</xs:sequence>
-		</xs:complexType>
-		<xs:unique name="uniqueSuiteName">
-			<xs:selector xpath=".//suite" />
-			<xs:field xpath="@name" />
-		</xs:unique>
-	</xs:element>
-
-
-
-	<xs:complexType name="BuildInfoType">
-		<xs:sequence>
-			<xs:element name="other" type="xs:string"></xs:element>
-		</xs:sequence>
-		<xs:attribute name="device_name" type="xs:string"></xs:attribute>
-		<xs:attribute name="device_model" type="xs:string"></xs:attribute>
-		<xs:attribute name="os_version" type="xs:string"></xs:attribute>
-		<xs:attribute name="device_id" type="xs:string"></xs:attribute>
-		<xs:attribute name="firmware_version" type="xs:string"></xs:attribute>
-		<xs:attribute name="screen_size" type="xs:string"></xs:attribute>
-		<xs:attribute name="resolution" type="xs:string"></xs:attribute>
-		<xs:attribute name="host" type="xs:string"></xs:attribute>
-		<xs:attribute name="cts_version" type="xs:string"></xs:attribute>
-		<xs:attribute name="build_id" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-
-	<xs:complexType name="summaryType">
-		<xs:sequence>
-			<xs:element name="start_at" type="xs:string"></xs:element>
-			<xs:element name="end_at" type="xs:string"></xs:element>
-		</xs:sequence>
-		<xs:attribute name="test_plan_name" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-
-	<xs:complexType name="specsType">
-		<xs:sequence>
-			<xs:element name="spec" type="specType" maxOccurs="unbounded"></xs:element>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="specType">
-		<xs:sequence>
-			<xs:element name="spec_assertion" type="spec_assertionType"></xs:element>
-			<xs:element name="spec_url" type="xs:string"></xs:element>
-			<xs:element name="spec_statement" type="xs:string"></xs:element>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="spec_assertionType">
-		<xs:attribute name="category" type="xs:string" use="required"></xs:attribute>
-		<xs:attribute name="section" type="xs:string" use="required"></xs:attribute>
-		<xs:attribute name="specification" type="xs:string" use="required">
-		</xs:attribute>
-		<xs:attribute name="interface" type="xs:string" use="required">
-		</xs:attribute>
-		<xs:attribute name="element_name" type="xs:string" use="optional">
-		</xs:attribute>
-		<xs:attribute name="usage" type="xs:boolean" default="false"></xs:attribute>
-		<xs:attribute name="element_type" type="xs:string"></xs:attribute>
-	</xs:complexType>
-
-	<xs:complexType name="CapabilitiesType">
-		<xs:sequence>
-			<xs:element name="capability" type="CapabilityType"
-				minOccurs="1" maxOccurs="unbounded"></xs:element>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="CapabilityType">
-		<xs:sequence minOccurs="0">
-			<xs:element name="value" type="xs:string"></xs:element>
-		</xs:sequence>
-		<xs:attribute name="name" type="xs:string" use="required"></xs:attribute>
-	</xs:complexType>
+  <xs:element name="suite">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element ref="set" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="set_attribute_group"/>
+      <xs:attribute name="launcher" type="xs:string"/>
+    </xs:complexType>
+    <xs:unique name="uniqueSetName">
+      <xs:selector xpath=".//set"/>
+      <xs:field xpath="@name"/>
+    </xs:unique>
+  </xs:element>
+  <xs:element name="set">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="capabilities" type="CapabilitiesType" minOccurs="0" maxOccurs="1"/>
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:attributeGroup ref="set_attribute_group"/>
+      <xs:attribute name="launcher" type="xs:string"/>
+      <xs:attribute name="set_debug_msg" type="xs:string"/>
+    </xs:complexType>
+    <xs:unique name="uniqueCaseName">
+      <xs:selector xpath=".//testcase"/>
+      <xs:field xpath="@id"/>
+    </xs:unique>
+  </xs:element>
+  <xs:element name="testcase">
+    <xs:complexType>
+      <xs:sequence minOccurs="1">
+        <xs:element ref="description"/>
+        <xs:element name="categories" type="categories" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="measurement" type="measurementType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="series" type="seriesType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="specs" type="specsType" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="result_info" type="result_info_type" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="case_attribute_group"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="steps">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="step"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="uniqueStepName">
+      <xs:selector xpath=".//step"/>
+      <xs:field xpath="@order"/>
+    </xs:unique>
+  </xs:element>
+  <xs:attributeGroup name="set_attribute_group">
+    <xs:attribute name="name" type="xs:anyURI" use="required"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="case_attribute_group">
+    <xs:attribute name="id" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:minLength value="1"/>
+          <xs:whiteSpace value="collapse"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="priority" type="priority_simple_type" use="required"/>
+    <xs:attribute name="execution_type" type="execution_type_simple_type" use="required"/>
+    <xs:attribute name="component" type="xs:string"/>
+    <xs:attribute name="requirement_ref" type="xs:anyURI" use="optional"/>
+    <xs:attribute name="status" type="status_type" use="required"/>
+    <xs:attribute name="type" type="case_type_type" use="required"/>
+    <xs:attribute name="purpose" type="xs:string"/>
+    <xs:attribute name="result" type="xs:string"/>
+    <xs:attribute name="onload_delay" type="xs:int" use="optional" default="3"/>
+  </xs:attributeGroup>
+  <xs:simpleType name="priority_simple_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="P0"/>
+      <xs:enumeration value="P1"/>
+      <xs:enumeration value="P2"/>
+      <xs:enumeration value="P3"/>
+      <xs:enumeration value="P4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="execution_type_simple_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="auto"/>
+      <xs:enumeration value="manual"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="status_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="designed"/>
+      <xs:enumeration value="ready"/>
+      <xs:enumeration value="approved"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="case_type_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="functional_positive"/>
+      <xs:enumeration value="functional_negative"/>
+      <xs:enumeration value="security"/>
+      <xs:enumeration value="performance"/>
+      <xs:enumeration value="reliability"/>
+      <xs:enumeration value="portability"/>
+      <xs:enumeration value="maintainability"/>
+      <xs:enumeration value="compliance"/>
+      <xs:enumeration value="user_experience"/>
+      <xs:enumeration value="undefined"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="purpose" type="xs:anySimpleType"/>
+  <xs:element name="notes" type="xs:string"/>
+  <xs:element name="pre_condition" type="xs:string"/>
+  <xs:element name="post_condition" type="xs:string"/>
+  <xs:element name="description">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element ref="notes"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element ref="pre_condition"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element ref="post_condition"/>
+        </xs:choice>
+        <xs:element ref="steps" minOccurs="1" maxOccurs="1"/>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element ref="test_script_entry"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="step">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="step_desc" type="xs:string"/>
+        <xs:element name="expected" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="order" type="xs:int"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="test_script_entry">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="test_script_expected_result" type="xs:string" default="0"/>
+          <xs:attribute name="timeout" type="xs:int" default="90"/>
+          <xs:attribute name="location" type="xs:string" default="device"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="result_info_type">
+    <xs:sequence minOccurs="0">
+      <xs:element name="actual_result" type="xs:string"/>
+      <xs:element name="start" type="xs:string"/>
+      <xs:element name="end" type="xs:string"/>
+      <xs:element name="stdout" type="xs:string" minOccurs="0"/>
+      <xs:element name="stderr" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="measurementType">
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="value" type="xs:string"/>
+    <xs:attribute name="unit" type="xs:string"/>
+    <xs:attribute name="target" type="xs:string"/>
+    <xs:attribute name="failure" type="xs:string"/>
+    <xs:attribute name="power" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="seriesType">
+    <xs:sequence>
+      <xs:element name="measurement" type="simpleMeasurementType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="group" type="xs:string"/>
+    <xs:attribute name="unit" type="xs:string"/>
+    <xs:attribute name="interval" type="xs:string"/>
+    <xs:attribute name="interval_unit" type="xs:string"/>
+    <xs:attribute name="power" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="simpleMeasurementType">
+    <xs:attribute name="value" type="xs:string"/>
+    <xs:attribute name="file" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="categories">
+    <xs:sequence>
+      <xs:element name="category" type="xs:string" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="test_definition">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="environment" type="BuildInfoType" minOccurs="0"/>
+        <xs:element name="summary" type="summaryType" minOccurs="0"/>
+        <xs:element ref="suite" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="uniqueSuiteName">
+      <xs:selector xpath=".//suite"/>
+      <xs:field xpath="@name"/>
+    </xs:unique>
+  </xs:element>
+  <xs:complexType name="BuildInfoType">
+    <xs:sequence>
+      <xs:element name="other" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="device_name" type="xs:string"/>
+    <xs:attribute name="device_model" type="xs:string"/>
+    <xs:attribute name="os_version" type="xs:string"/>
+    <xs:attribute name="device_id" type="xs:string"/>
+    <xs:attribute name="firmware_version" type="xs:string"/>
+    <xs:attribute name="screen_size" type="xs:string"/>
+    <xs:attribute name="resolution" type="xs:string"/>
+    <xs:attribute name="host" type="xs:string"/>
+    <xs:attribute name="cts_version" type="xs:string"/>
+    <xs:attribute name="build_id" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="summaryType">
+    <xs:sequence>
+      <xs:element name="start_at" type="xs:string"/>
+      <xs:element name="end_at" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="test_plan_name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="specsType">
+    <xs:sequence>
+      <xs:element name="spec" type="specType" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="specType">
+    <xs:sequence>
+      <xs:element name="spec_assertion" type="spec_assertionType"/>
+      <xs:element name="spec_url" type="xs:string"/>
+      <xs:element name="spec_statement" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="spec_assertionType">
+    <xs:attribute name="category" type="xs:string" use="required"/>
+    <xs:attribute name="section" type="xs:string" use="required"/>
+    <xs:attribute name="specification" type="xs:string" use="required"/>
+    <xs:attribute name="interface" type="xs:string" use="required"/>
+    <xs:attribute name="element_name" type="xs:string" use="optional"/>
+    <xs:attribute name="usage" type="xs:boolean" default="false"/>
+    <xs:attribute name="element_type" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="CapabilitiesType">
+    <xs:sequence>
+      <xs:element name="capability" type="CapabilityType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CapabilityType">
+    <xs:sequence minOccurs="0">
+      <xs:element name="value" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
 </xs:schema>
-


### PR DESCRIPTION
Reference: http://xmlsoft.org/xmllint.html

This just formats the test_definition.xsd indent with 2 spaces,
and removes empty line.
No code logic change.
