### PR TITLE
Optimize testenvs parameter parse when the test environment key's value contains '=' character.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 [public_version]
 version=3.1.17
 [internal_version]
-version=3.1.17-rc1
+version=3.1.17-rc4

--- a/testkit-lite
+++ b/testkit-lite
@@ -323,7 +323,7 @@ to resolve this issue" % (LOG_DIR)
             env_t = env_t.strip()
             if not env_t:
                 continue
-            k, v = env_t.split('=')
+            k, v = env_t.split('=', 1)
             if 'app_launcher' in v:
                 os.environ[k.strip()] = "app_launcher -s"
             else:
@@ -389,7 +389,7 @@ to resolve this issue" % (LOG_DIR)
             env_t = env_t.strip()
             if not env_t:
                 continue
-            k, v = env_t.split('=')
+            k, v = env_t.split('=', 1)
             if 'app_launcher' in v:
                 os.environ[k.strip()] = "app_launcher -s"
             else:


### PR DESCRIPTION
BUG=https://crosswalk-project.org/jira/browse/CTS-624