### PR TITLE
Remove set_page_load_timeout method for webdriver test.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 [public_version]
 version=3.1.18
 [internal_version]
-version=3.1.18-rc2
+version=3.1.18-rc3

--- a/testkitlite/engines/test_executer.py
+++ b/testkitlite/engines/test_executer.py
@@ -457,7 +457,6 @@ class TestExecuter:
 
             i_page_url = '%s%s' % (self.test_prefix, entry_url)
             try:
-                self.web_driver.set_page_load_timeout(i_case_timeout)
                 sub_index = self.__getCaseIndex(i_case['entry'])
                 if not url_equal:
                     self.web_driver.get(i_page_url)
@@ -592,7 +591,6 @@ class TestExecuter:
 
             i_page_url = '%s%s' % (self.test_prefix, entry_url)
             try:
-                self.web_driver.set_page_load_timeout(i_case_timeout)
                 sub_index = int(i_case['entry'].split("testNumber=")[1]) - 1
                 if not url_equal:
                     self.web_driver.get(i_page_url)


### PR DESCRIPTION
Upgrade internal-version as 3.1.18-rc3 for release.